### PR TITLE
Add a 10 second option to the timer

### DIFF
--- a/Modules/BilliardsModule/UdonScripts/MenuManager.cs
+++ b/Modules/BilliardsModule/UdonScripts/MenuManager.cs
@@ -8,7 +8,7 @@ using TMPro;
 [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
 public class MenuManager : UdonSharpBehaviour
 {
-    private readonly byte[] TIMER_VALUES = new byte[] { 0, 60, 45, 30, 15 };
+    private readonly byte[] TIMER_VALUES = new byte[] { 0, 60, 45, 30, 15, 10 };
 
     [SerializeField] private GameObject menuStart;
     [SerializeField] private GameObject menuJoinLeave;

--- a/Modules/BilliardsModule/UdonScripts/MenuManager.cs
+++ b/Modules/BilliardsModule/UdonScripts/MenuManager.cs
@@ -342,13 +342,13 @@ public class MenuManager : UdonSharpBehaviour
         if (selectedTimer > 0)
             selectedTimer--;
         else
-            selectedTimer = 4;
+            selectedTimer = TIMER_VALUES.Length - 1;
 
         table._TriggerTimerChanged(TIMER_VALUES[selectedTimer]);
     }
     public void TimeLeft()
     {
-        if (selectedTimer < 4)
+        if (selectedTimer < TIMER_VALUES.Length - 1)
             selectedTimer++;
         else
             selectedTimer = 0;
@@ -481,7 +481,7 @@ public class MenuManager : UdonSharpBehaviour
             }
             else if (button.name == "TimeLeft")
             {
-                if (selectedTimer < 3)
+                if (selectedTimer < TIMER_VALUES.Length - 2)
                 {
                     selectedTimer++;
 


### PR DESCRIPTION
I'm an avid player of pool tables with a 10 second countdown, it's something present on the community edition of the table and I'd love to see it on this version as well.

I'm not 100% sure other changes aren't also needed, do tell me if there are or if there's any process you'd like for PRs