### PR TITLE
omitted no-cushion foul rare case in 8ball

### DIFF
--- a/Modules/BilliardsModule/UdonScripts/BilliardsModule.cs
+++ b/Modules/BilliardsModule/UdonScripts/BilliardsModule.cs
@@ -1595,7 +1595,7 @@ public class BilliardsModule : UdonSharpBehaviour
                     moveBallInDirUntilNotTouching(1, Vector3.right * k_BALL_RADIUS * .051f);
                 }
 
-                foulCondition = isScratch || isWrongHit || fallOffFoul || (!isObjectiveSink && (!ballBounced || (colorTurnLocal && numBallsHitCushion < 4)));
+                foulCondition = isScratch || isWrongHit || fallOffFoul || ((!isObjectiveSink && !isOpponentSink) && (!ballBounced || (colorTurnLocal && numBallsHitCushion < 4)));
 
                 if (isScratch && colorTurnLocal)
                 {


### PR DESCRIPTION
コンビネーションショットやキャノンショットで相手のグループボールを落とした場合にクッションに触っていなかったらノークッションファウルになってしまう（8Ball）

-----
If you drop an opponent's group ball on a combination or cannon shot and you didn't touch the cushion, it's a no cushion foul.(8ball)