### PR TITLE
4BallとSnookerでテーブルのチームカラーが逆になる場合がある | Team colors on table may be reversed for 4Ball and Snooker

### DIFF
--- a/Modules/BilliardsModule/UdonScripts/NetworkingManager.cs
+++ b/Modules/BilliardsModule/UdonScripts/NetworkingManager.cs
@@ -410,6 +410,7 @@ public class NetworkingManager : UdonSharpBehaviour
         turnStateSynced = 0;
         isTableOpenSynced = true;
         teamIdSynced = 0;
+        teamColorSynced = 0;
         fourBallCueBallSynced = 0;
         cueBallVSynced = Vector3.zero;
         cueBallWSynced = Vector3.zero;


### PR DESCRIPTION
4BallとSnookerでテーブルのチームカラーが逆になる場合がある
----
Team colors on table may be reversed for 4Ball and Snooker
-
1. start 8ball game
2. team0 player choice high-ball (table close. color orange. team=0,teamColor=1)
3. game reset
4. start 4ball (table team0 indicate color yellow)

<img width="1081" alt="BugCaromTeamColor" src="https://github.com/user-attachments/assets/f3f578f1-98a8-4c4a-9bc5-679b86e693c0" />
