### PR TITLE
Fixed a bug where the position of the sphere might not synchronize when moved in Desktop View

### DIFF
--- a/Modules/BilliardsModule/UdonScripts/DesktopManager.cs
+++ b/Modules/BilliardsModule/UdonScripts/DesktopManager.cs
@@ -30,6 +30,7 @@ public class DesktopManager : UdonSharpBehaviour
     private bool holdingCue;
     private bool inUI;
     private bool repositionMode;
+    private bool waitingMouse0Release = false;
 
     private bool isShooting;
     private bool isRepositioning;
@@ -156,7 +157,21 @@ public class DesktopManager : UdonSharpBehaviour
                     renderCuePosition(initialShotDirection);
                     stopShooting();
                 }
-                repositionMode = !repositionMode;
+                if (repositionMode)
+                {
+                    if (isRepositioning)
+                    {
+                        waitingMouse0Release = true;
+                    }
+                    else
+                    {
+                        repositionMode = false;
+                    }
+                }
+                else
+                {
+                    repositionMode = true;
+                }
             }
         }
 
@@ -206,6 +221,11 @@ public class DesktopManager : UdonSharpBehaviour
                 {
                     isRepositioning = false;
                     stopRepositioning();
+                    if (waitingMouse0Release)
+                    {
+                        repositionMode = false;
+                        waitingMouse0Release = false;
+                    }
                 }
             }
             else


### PR DESCRIPTION
# デスクトップビューで球を移動させると位置が同期しない場合がある不具合を修正 | Fixed a bug where the position of the sphere might not synchronize when moved in Desktop View

## 以下の不具合を修正するものです。

再現手順
1. Desktop mode で Desktop View に Eキー で切り替える
2. Qキー で reposition mode に切り替えて玉をドラッグして移動する
3. マウスボタンを離す前に（ドラッグで押しっぱなしのまま）Qキーで抜けたときだけ位置の同期ずれが発生する